### PR TITLE
Add Makefile for standardized releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+ifeq ($(words $(MAKECMDGOALS)), 1)
+	LEVEL = minor
+else
+	LEVEL = $(filter-out $@,$(MAKECMDGOALS))
+endif
+
+release: package.json
+	git pull --rebase
+	npm test
+	npm version $(LEVEL)
+	npm publish
+	git push --follow-tags
+
+%:
+	@:


### PR DESCRIPTION
As per discussion in #7

Based on @sindresorhus's gist, but customized for this repo to account for the fact that there are no dependencies and that the default version bump should be minor (since patch should basically never happen here).
