### PR TITLE
move `arguments` from builtin to node

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -1,6 +1,5 @@
 {
 	"builtin": {
-		"arguments": false,
 		"Array": false,
 		"ArrayBuffer": false,
 		"Boolean": false,
@@ -413,6 +412,7 @@
 	"node": {
 		"__filename": false,
 		"__dirname": false,
+		"arguments": false,
 		"Buffer": false,
 		"DataView": false,
 		"console": false,


### PR DESCRIPTION
node's "top-level" execution context is not actually top-level because they run the program in a function body. This has many consequences, including introducing `arguments` into scope at the "top-level". For more info see https://github.com/joyent/node/issues/6254. In general, `arguments` is not a global variable and should not be in the builtin list.
