### PR TITLE
Add support for Mongo shell

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -700,5 +700,33 @@
 		"Utils": false,
 		"WebApp": false,
 		"WebAppInternals": false
+	},
+	"mongo": {
+		"_isWindows": false,
+		"_rand": false,
+		"BulkWriteResult": false,
+		"cat": false,
+		"cd": false,
+		"connect": false,
+		"db": false,
+		"getHostName": false,
+		"getMemInfo": false,
+		"hostname": false,
+		"listFiles": false,
+		"load": false,
+		"ls": false,
+		"md5sumFile": false,
+		"mkdir": false,
+		"Mongo": false,
+		"ObjectId": false,
+		"PlanCache": false,
+		"pwd": false,
+		"quit": false,
+		"removeFile": false,
+		"rs": false,
+		"sh": false,
+		"UUID": false,
+		"version": false,
+		"WriteResult": false
 	}
 }


### PR DESCRIPTION
I scraped them from [these docs](http://docs.mongodb.org/manual/reference/method/) and removed the ones marked as "internal use only". They are all writable in the following sense:
```javascript
ObjectId = 1;
Objectid === 1; // true
```
I'm not sure whether this is what the boolean flag is supposed to mean.