### PR TITLE
support JS-format AppleScripts

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -732,5 +732,17 @@
 		"UUID": false,
 		"version": false,
 		"WriteResult": false
+	},
+	"applescript": {
+		"console": false,
+		"Automation": false,
+		"Progress": false,
+		"ObjC": false,
+		"Path": false,
+		"Library": false,
+		"Ref": false,
+		"$": false,
+		"Application": false,
+		"ObjectSpecifier": false
 	}
 }


### PR DESCRIPTION
OSX 10.10 "Yosemite" added a JavaScriptCore-based interpreter to the AppleScript framework.
These scripts use some funky new globals to create Cocoa objects and access Mac applications for automation scripting, on top of envs `builtin` & `nonstandard`.
Check out `/usr/bin/osascript -l JavaScript -e 'this'` for a full API listing.