### PR TITLE
Add undocumented 'root' global for node

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -467,6 +467,7 @@
 		"module": false,
 		"process": false,
 		"require": false,
+		"root": false,
 		"setImmediate": false,
 		"setInterval": false,
 		"setTimeout": false


### PR DESCRIPTION
While it'll be deprecated along with `GLOBAL` [eventually](https://github.com/nodejs/io.js/pull/1838), it should be here for completeness sake.