### PR TITLE
Remove nonstandard category

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -11,6 +11,7 @@
 		"encodeURI": false,
 		"encodeURIComponent": false,
 		"Error": false,
+		"escape": false,
 		"eval": false,
 		"EvalError": false,
 		"Float32Array": false,
@@ -52,14 +53,11 @@
 		"Uint8Array": false,
 		"Uint8ClampedArray": false,
 		"undefined": false,
+		"unescape": false,
 		"URIError": false,
 		"valueOf": false,
 		"WeakMap": false,
 		"WeakSet": false
-	},
-	"nonstandard": {
-		"escape": false,
-		"unescape": false
 	},
 	"browser": {
 		"addEventListener": false,


### PR DESCRIPTION
See https://github.com/sindresorhus/globals/issues/35 for discussion on this. The prime motivation is to get these two recognized by eslint, which as it stands doesn't import the nonstandard category into any environment.