### PR TITLE
Add ember test globals

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -971,7 +971,7 @@
 		"ServiceWorkerRegistration": false,
 		"WindowClient": false
 	},
-	"ember": {
+	"embertest": {
 		"andThen": false,
 		"click": false,
 		"currentPath": false,

--- a/globals.json
+++ b/globals.json
@@ -972,15 +972,15 @@
 		"WindowClient": false
 	},
 	"ember": {
+		"andThen": false,
 		"click": false,
-		"fillIn": false,
-		"keyEvent": false,
-		"triggerEvent": false,
-		"visit": false,
 		"currentPath": false,
 		"currentRouteName": false,
 		"currentUrl": false,
+		"fillIn": false,
 		"find": false,
-		"andThen": false
+		"keyEvent": false,
+		"triggerEvent": false,
+		"visit": false
 	}
 }

--- a/globals.json
+++ b/globals.json
@@ -970,5 +970,17 @@
 		"ServiceWorkerMessageEvent": false,
 		"ServiceWorkerRegistration": false,
 		"WindowClient": false
+	},
+	"ember": {
+		"click": false,
+		"fillIn": false,
+		"keyEvent": false,
+		"triggerEvent": false,
+		"visit": false,
+		"currentPath": false,
+		"currentRouteName": false,
+		"currentUrl": false,
+		"find": false,
+		"andThen": false
 	}
 }


### PR DESCRIPTION
Since the entries weren't sorted alphabetically I've just added the globals at the end. They're under the `ember` key,  but I can change that to `ember.test` if you'd like. Let me know if there's anything that should be changed!

Closes #42 