### PR TITLE
Define "expect" in jest environment

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -725,6 +725,7 @@
 		"afterEach": false,
 		"beforeEach": false,
 		"describe": false,
+		"expect": false,
 		"it": false,
 		"jest": false,
 		"pit": false,


### PR DESCRIPTION
Even if it is not listed in the documentation under [Globally injected variables](http://facebook.github.io/jest/docs/api.html#globally-injected-variables), `expect` is indeed injected globally, like jasmine does. You can see its usage in the [Getting started](http://facebook.github.io/jest/docs/getting-started.html#content) example.