### PR TITLE
Add `shared-node-browser` environment

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -1094,5 +1094,12 @@
 		"DartObject": false,
 		"element": false,
 		"protractor": false
+	},
+	"shared-node-browser": {
+		"clearInterval": false,
+		"clearTimeout": false,
+		"console": false,
+		"setInterval": false,
+		"setTimeout": false
 	}
 }


### PR DESCRIPTION
Adds a new environment, `universal` which only has the intersection of `node` and `browser` for "isomorphic" JavaScript.