### PR TITLE
Add 'nashorn' environment

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -863,6 +863,26 @@
 		"toint32": false,
 		"version": false
 	},
+	"nashorn": {
+		"load": false,
+		"loadWithNewGlobal": false,
+		"print": false,
+		"__FILE__": false,
+		"__LINE__": false,
+		"__DIR__": false,
+		"exit": false,
+		"quit": false,
+		"Java": false,
+		"JavaImporter": false,
+		"JSAdapter": false,
+		"Packages": false,
+		"java": false,
+		"javax": false,
+		"javafx": false,
+		"com": false,
+		"edu": false,
+		"org": false
+	},
 	"wsh": {
 		"ActiveXObject": true,
 		"Enumerator": true,


### PR DESCRIPTION
Java 8 ships with a new JavaScript Engine called Nashorn as the successor of Rhino. This PR defines all global variables for the nashorn environment as officially described here:

https://wiki.openjdk.java.net/display/Nashorn/Nashorn+extensions

As a side note: A few more global variables such as `$ENV` are available when using Nashorn in  *scripting mode*. I have intentionally skipped those special variables. They could be added e.g. in an additional `nashorn-scripting` environment when needed.