### PR TITLE
Add WebExtensions globals.

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -1094,5 +1094,10 @@
 		"DartObject": false,
 		"element": false,
 		"protractor": false
+	},
+	"webextensions": {
+		"chrome": false,
+		"opr": false,
+		"browser": false
 	}
 }


### PR DESCRIPTION
As per [Chrome’s documentation](https://developer.chrome.com/extensions/api_index), [Opera’s documentation](https://dev.opera.com/extensions/index.html), and [Firefox’s documentation](https://wiki.mozilla.org/WebExtensions).