### PR TITLE
Handling of wsh environment

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -1107,17 +1107,17 @@
 		"chrome": false,
 		"opr": false
 	},
-  "wsh": {
-	"ActiveXObject": false,
-	"Enumerator": false,
-	"GetObject": false,
-	"ScriptEngine": false,
-	"ScriptEngineBuildVersion": false,
-	"ScriptEngineMajorVersion": false,
-	"ScriptEngineMinorVersion": false,
-	"VBArray": false,
-	"WSH": false,
-	"WScript": false,
-	"XDomainRequest": false
-  }
+	"wsh": {
+		"ActiveXObject": false,
+		"Enumerator": false,
+		"GetObject": false,
+		"ScriptEngine": false,
+		"ScriptEngineBuildVersion": false,
+		"ScriptEngineMajorVersion": false,
+		"ScriptEngineMinorVersion": false,
+		"VBArray": false,
+		"WSH": false,
+		"WScript": false,
+		"XDomainRequest": false
+	}
 }

--- a/globals.json
+++ b/globals.json
@@ -1106,5 +1106,18 @@
 		"browser": false,
 		"chrome": false,
 		"opr": false
-	}
+	},
+  "wsh": {
+	"ActiveXObject": false,
+	"Enumerator": false,
+	"GetObject": false,
+	"ScriptEngine": false,
+	"ScriptEngineBuildVersion": false,
+	"ScriptEngineMajorVersion": false,
+	"ScriptEngineMinorVersion": false,
+	"VBArray": false,
+	"WSH": false,
+	"WScript": false,
+	"XDomainRequest": false
+  }
 }


### PR DESCRIPTION
HI !

I am working on a project were I just integrated ESLint. I discovered that this tool does not handle wsh environment (i.e. WScript & cscript). I modified this globals.json (based on jshint globals definition) to add the support of wsh environment to ESLint.

This is my first pull request, I apologize in advance if I did anything wrong... Let me know !

Thanks,
- Arnaud