### PR TITLE
add 'greasemonkey' environment

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -1212,5 +1212,21 @@
 		"browser": false,
 		"chrome": false,
 		"opr": false
+	},
+	"greasemonkey": {
+		"GM_addStyle": false,
+		"GM_deleteValue": false,
+		"GM_getResourceText": false,
+		"GM_getResourceURL": false,
+		"GM_getValue": false,
+		"GM_info": false,
+		"GM_listValues": false,
+		"GM_log": false,
+		"GM_openInTab": false,
+		"GM_registerMenuCommand": false,
+		"GM_setClipboard": false,
+		"GM_setValue": false,
+		"GM_xmlhttpRequest": false,
+		"unsafeWindow": false
 	}
 }


### PR DESCRIPTION
This is the [Userscript API](http://wiki.greasespot.net/Greasemonkey_Manual:API) available in [Greasemonkey](https://addons.mozilla.org/en-US/firefox/addon/greasemonkey/), [Tampermonkey](https://chrome.google.com/webstore/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo) and compatible engines.