### PR TITLE
Add findWithAssert and pauseTest to embertest

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -1187,7 +1187,9 @@
 		"currentURL": false,
 		"fillIn": false,
 		"find": false,
+		"findWithAssert": false,
 		"keyEvent": false,
+		"pauseTest": false,
 		"triggerEvent": false,
 		"visit": false
 	},


### PR DESCRIPTION
This completes the list of test helpers that people may be accessing via globals. There are other test helpers listed on http://emberjs.com/api/classes/Ember.Test.html but they should not be accessed via globals.