### PR TITLE
add 'atomtest' environment

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -1179,6 +1179,15 @@
 		"skipWaiting": false,
 		"WindowClient": false
 	},
+	"atomtest": {
+		"advanceClock": false,
+		"fakeClearInterval": false,
+		"fakeClearTimeout": false,
+		"fakeSetInterval": false,
+		"fakeSetTimeout": false,
+		"resetTimeouts": false,
+		"waitsForPromise": false
+	},
 	"embertest": {
 		"andThen": false,
 		"click": false,


### PR DESCRIPTION
Following the naming convention from #43, this adds the globals found in Atom package tests (see https://github.com/atom/atom/blob/329d7f4/spec/spec-helper.coffee).