### PR TITLE
Blob is available in worker context

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -756,6 +756,7 @@
 	"worker": {
 		"applicationCache": false,
 		"atob": false,
+		"Blob": false,
 		"BroadcastChannel": false,
 		"btoa": false,
 		"Cache": false,


### PR DESCRIPTION
This adds `Blob` to the worker environment, since that API is available there.