### PR TITLE
Add global to commonjs

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -844,7 +844,8 @@
 	"commonjs": {
 		"exports": true,
 		"module": false,
-		"require": false
+		"require": false,
+		"global": false
 	},
 	"amd": {
 		"define": false,


### PR DESCRIPTION
All the CommonJS wrappers (browserify, webpack, etc.) include `global` in their environments.

Related: https://github.com/eslint/eslint/issues/4728