### PR TITLE
Fix: remove `Float*Array` from `es5`

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -72,8 +72,6 @@
 		"escape": false,
 		"eval": false,
 		"EvalError": false,
-		"Float32Array": false,
-		"Float64Array": false,
 		"Function": false,
 		"hasOwnProperty": false,
 		"Infinity": false,


### PR DESCRIPTION
I guess these have been forgotten.