### PR TITLE
Add globals for New Relic Synthetics.

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -1243,5 +1243,10 @@
 		"GM_setValue": false,
 		"GM_xmlhttpRequest": false,
 		"unsafeWindow": false
+	},
+	"newrelic": {
+		"$browser": false,
+		"$driver": false,
+		"$util": false
 	}
 }


### PR DESCRIPTION
Adds globals used by [New Relic Synthetics](http://newrelic.com/synthetics). I didn't find any pages listing all global variables they create but these are the three I know about from [this page](https://docs.newrelic.com/docs/synthetics/new-relic-synthetics/scripting-monitors/synthetics-scripted-browser-reference#structure) and [this page](https://docs.newrelic.com/docs/synthetics/new-relic-synthetics/scripting-monitors/add-insights-attributes-synthetics-events).