### PR TITLE
Make status a writable property in browser environments

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -526,7 +526,7 @@
 		"speechSynthesis": false,
 		"SpeechSynthesisEvent": false,
 		"SpeechSynthesisUtterance": false,
-		"status": false,
+		"status": true,
 		"statusbar": false,
 		"stop": false,
 		"Storage": false,


### PR DESCRIPTION
Per the spec status is a writable property on DOM window objects: https://html.spec.whatwg.org/multipage/browsers.html#the-window-object