### PR TITLE
add `Intl` for nodejs

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -833,6 +833,7 @@
 		"exports": true,
 		"GLOBAL": false,
 		"global": false,
+		"Intl": false,
 		"module": false,
 		"process": false,
 		"require": false,


### PR DESCRIPTION
The current version of Node.js (5.10.0) and versions going back at least
to 0.12.7 have the `Intl` global.