### PR TITLE
Add fit to Jest globals

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -911,6 +911,7 @@
 		"describe": false,
 		"expect": false,
 		"it": false,
+		"fit": false,
 		"jest": false,
 		"pit": false,
 		"require": false,


### PR DESCRIPTION
This adds the `fit` variable to Jest's list of global variables, which is currently missing but exported by Jest.

http://facebook.github.io/jest/docs/api.html#globally-injected-variables