### PR TITLE
add mocha's global run() function

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -883,6 +883,7 @@
 		"describe": false,
 		"it": false,
 		"mocha": false,
+		"run": false,
 		"setup": false,
 		"specify": false,
 		"suite": false,


### PR DESCRIPTION
`run()` is available globally when [`delay` mode](https://mochajs.org#delayed-root-suite) is used