### PR TITLE
Add `customElements` to browser env

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -239,6 +239,7 @@
 		"CSSTransition": false,
 		"CSSUnknownRule": false,
 		"CSSViewportRule": false,
+		"customElements": false,
 		"CustomEvent": false,
 		"DataTransfer": false,
 		"DataTransferItem": false,


### PR DESCRIPTION
It was added for Custom Elements v1.  At least Chrome already implemented this.

ref: https://developers.google.com/web/fundamentals/getting-started/primers/customelements