### PR TITLE
Add `resumeTest` to `embertest`

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -1246,6 +1246,7 @@
 		"findWithAssert": false,
 		"keyEvent": false,
 		"pauseTest": false,
+		"resumeTest": false,
 		"triggerEvent": false,
 		"visit": false
 	},


### PR DESCRIPTION
Added in https://github.com/emberjs/ember.js/pull/13663, and enabled in https://github.com/emberjs/ember.js/pull/14981.

This is available from Ember 2.13+.