### PR TITLE
Add cancelIdleCallback to browser

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -196,6 +196,7 @@
 		"caches": false,
 		"CacheStorage": false,
 		"cancelAnimationFrame": false,
+		"cancelIdleCallback": false,
 		"CanvasGradient": false,
 		"CanvasPattern": false,
 		"CanvasRenderingContext2D": false,


### PR DESCRIPTION
This is the counterpart of `requestIdleCallback`, which was added by #101.

https://developer.mozilla.org/en-US/docs/Web/API/Window/cancelIdleCallback

cc @amilajack