### PR TITLE
Add AbortController, AbortSignal in "browser" environment

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -221,6 +221,8 @@
 		"WeakSet": false
 	},
 	"browser": {
+		"AbortController": false,
+		"AbortSignal": false,
 		"addEventListener": false,
 		"alert": false,
 		"AnalyserNode": false,


### PR DESCRIPTION
AbortController, AbortSignal are implemented already in Firefox + Edge, and soon in Chrome (crbug.com/750599)

I realize that this project typically only imports globals from Chrome canary and defines those as the "browser environment". However, it seems that Chrome is the last browser to implement abortable fetch and not having AbortController, AbortSignal recognized as globals is causing some problems; I've implemented a polyfill for AbortController (mostly for IE 11 etc) but right now it cannot be used (without springling eslint suppressions) in projects based on "create-react-app" because CRA defined no-undef as a build error and eslint doesn't know that "AbortController" is part of the browser API. More specifically, I would like to avoid telling all users of abortcontroller-polyfill that they have to pollute all their files with:
https://github.com/mo/abortcontroller-polyfill-create-react-app-example/blob/82f93009865ed58036520ebb46114cbec033a3f6/src/App.js#L9

Would you be willing to carry this little "patch" on top of the auto generated list of globals for a short while? If not, would you be ok with a patch that automatically adds these two entries when get-browser-globals.js runs?