### PR TITLE
Add BigInt to builtin

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -3,6 +3,7 @@
 		"Array": false,
 		"ArrayBuffer": false,
 		"Atomics": false,
+		"BigInt": false,
 		"Boolean": false,
 		"constructor": false,
 		"DataView": false,


### PR DESCRIPTION
`BigInt` is available in Node.js 10.4.0 and Chrome 67. I think it's rather unlikely that the current stage 3 proposal will not be made a standard, so I added it to `builtin`.