### PR TITLE
add BigInt64Array and BigUint64Array to builtin

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -4,6 +4,8 @@
 		"ArrayBuffer": false,
 		"Atomics": false,
 		"BigInt": false,
+		"BigInt64Array": false,
+		"BigUint64Array": false,
 		"Boolean": false,
 		"constructor": false,
 		"DataView": false,


### PR DESCRIPTION
Sorry, I forgot those two on the last PR. [Reference](https://github.com/nodejs/node/pull/19989#issuecomment-388634301) here.