### PR TITLE
fix yui global variables

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -1191,10 +1191,10 @@
 		"jQuery": false
 	},
 	"yui": {
-		"YUI": false,
-		"YUI_config": false,
 		"YAHOO": false,
-		"YAHOO_config": false
+		"YAHOO_config": false,
+		"YUI": false,
+		"YUI_config": false
 	},
 	"shelljs": {
 		"cat": false,

--- a/globals.json
+++ b/globals.json
@@ -1191,9 +1191,10 @@
 		"jQuery": false
 	},
 	"yui": {
-		"Y": false,
 		"YUI": false,
-		"YUI_config": false
+		"YUI_config": false,
+		"YAHOO": false,
+		"YAHOO_config": false
 	},
 	"shelljs": {
 		"cat": false,


### PR DESCRIPTION
`Y` is not a global variable it's just a conventional name for the reference of the YUI instance.

## reference

YUI 3: https://yuilibrary.com/yui/docs/api/classes/YUI.html#property_YUI_config
YUI 2: http://yui.github.io/yui2/docs/yui_2.9.0_full/yahoo/#config

## context

eslint/eslint#10775