### PR TITLE
Add `WorkerGlobalScope` to `worker` environment

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -996,7 +996,7 @@
 		"URLSearchParams": false,
 		"WebSocket": false,
 		"Worker": false,
-		"WorkerGlobalScope": true,
+		"WorkerGlobalScope": false,
 		"XMLHttpRequest": false
 	},
 	"node": {

--- a/globals.json
+++ b/globals.json
@@ -996,6 +996,7 @@
 		"URLSearchParams": false,
 		"WebSocket": false,
 		"Worker": false,
+		"WorkerGlobalScope": true,
 		"XMLHttpRequest": false
 	},
 	"node": {


### PR DESCRIPTION
[`WorkerGlobalScope`](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope) is defined in Web Workers, it's exists [basically everywhere](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope#Browser_compatibility) and it's [useful for environment detection](https://stackoverflow.com/a/18002694/2048874). This PR fixes #127.