### PR TITLE
Change `location` in the browser environment to be a read-write global, rather than read-only

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -485,7 +485,7 @@
 		"KeyframeEffectReadOnly": false,
 		"length": false,
 		"localStorage": false,
-		"location": false,
+		"location": true,
 		"Location": false,
 		"locationbar": false,
 		"matchMedia": false,


### PR DESCRIPTION
The "location" property on a window is writeable not just read-only, so I think we should update the globals list to handle this.

See the discussion in the first two comments on this bug for details: https://bugzilla.mozilla.org/show_bug.cgi?id=1509270