### PR TITLE
Add `globalThis` to `builtin` environment

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -21,6 +21,7 @@
 		"Float32Array": false,
 		"Float64Array": false,
 		"Function": false,
+		"globalThis": false,
 		"hasOwnProperty": false,
 		"Infinity": false,
 		"Int16Array": false,


### PR DESCRIPTION
It's been available since Node.js v11.0.0.

Refs: https://github.com/nodejs/node/pull/27399

It's also available in (at least) recent Chrome and Firefox but I don't know what your policy is w.r.t. to something that only a subset of browsers support.