### PR TITLE
Add a global for `wsh`

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -1186,6 +1186,7 @@
 	},
 	"wsh": {
 		"ActiveXObject": true,
+		"Debug": true,
 		"Enumerator": true,
 		"GetObject": true,
 		"ScriptEngine": true,


### PR DESCRIPTION
This PR removes the `XDomainRequest` global for WSH, which is not documented in
the [JScript Reference] or [WSH Reference] and not present on Windows 7 or Windows 10 (the only versions I checked).

It also adds [`Debug`], which is provided by JScript 3 and later (released with IE 4) which WSH uses.  I confirmed it is present on Windows 7 and 10.

Thanks for considering,
Kevin

[`Debug`]: https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/scripting-articles/bs12a9wf(v=vs.84)
[JScript Reference]: https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/scripting-articles/yek4tbz0(v=vs.84)
[WSH Reference]: https://docs.microsoft.com/en-us/previous-versions//98591fh7%28v%3dvs.85%29
