### PR TITLE
Add CollectGarbage and RuntimeObject to wsh

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -1186,6 +1186,7 @@
 	},
 	"wsh": {
 		"ActiveXObject": true,
+		"CollectGarbage": true,
 		"Debug": true,
 		"Enumerator": true,
 		"GetObject": true,

--- a/globals.json
+++ b/globals.json
@@ -1190,6 +1190,7 @@
 		"Debug": true,
 		"Enumerator": true,
 		"GetObject": true,
+		"RuntimeObject": true,
 		"ScriptEngine": true,
 		"ScriptEngineBuildVersion": true,
 		"ScriptEngineMajorVersion": true,


### PR DESCRIPTION
This PR adds two additional global functions provided by JScript in Windows Script Host and specified by Microsoft:

* [CollectGarbage] is a function provided by JScript on the global object which triggers the garbage collector.  It is required to [work around ActiveX object retention issues] in some situations.
* [RuntimeObject] is a function provided by JScript on the global object for enumerating functions and variables defined in the global scope.

I can confirm both variables are present on both Windows 7 and 10.

Thanks,
Kevin

[CollectGarbage]: https://docs.microsoft.com/en-us/openspecs/ie_standards/ms-es3ex/73a13f4c-72b3-48f3-b2f4-933084ec8716
[RuntimeObject]: https://docs.microsoft.com/en-us/openspecs/ie_standards/ms-es3ex/a17cdcdb-ef33-43e0-b269-9634e59b1a00
[work around ActiveX object retention issues]: https://docs.microsoft.com/en-us/office/troubleshoot/excel/jscript-not-shut-down-excel