### PR TITLE
Add true globals for Node.js

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -1027,6 +1027,24 @@
 		"URL": false,
 		"URLSearchParams": false
 	},
+	"nodeBuiltin": {
+		"Buffer": false,
+		"clearImmediate": false,
+		"clearInterval": false,
+		"clearTimeout": false,
+		"console": false,
+		"global": false,
+		"Intl": false,
+		"process": false,
+		"queueMicrotask": false,
+		"setImmediate": false,
+		"setInterval": false,
+		"setTimeout": false,
+		"TextDecoder": false,
+		"TextEncoder": false,
+		"URL": false,
+		"URLSearchParams": false
+	},
 	"commonjs": {
 		"exports": true,
 		"global": false,

--- a/readme.md
+++ b/readme.md
@@ -35,18 +35,15 @@ console.log(globals.browser);
 
 Each global is given a value of `true` or `false`. A value of `true` indicates that the variable may be overwritten. A value of `false` indicates that the variable should be considered read-only. This information is used by static analysis tools to flag incorrect behavior. We assume all variables should be `false` unless we hear otherwise.
 
-For node.js this package provides two sets of globals:
+For Node.js this package provides two sets of globals:
 
-* `globals.nodeBuiltin`: Globals available to all code running in node.js.
-  These will usually be available as properties on the `global` object and
-  include `process`, `Buffer` but not CommonJS arguments like `require`.
-  See: https://nodejs.org/api/globals.html
-* `globals.node`: A combination of the globals from `nodeBuiltin` plus all
-  CommonJS arguments ("CommonJS module scope").
-  See: https://nodejs.org/api/modules.html#modules_the_module_scope
+- `globals.nodeBuiltin`: Globals available to all code running in Node.js.
+	These will usually be available as properties on the `global` object and include `process`, `Buffer`, but not CommonJS arguments like `require`.
+	See: https://nodejs.org/api/globals.html
+- `globals.node`: A combination of the globals from `nodeBuiltin` plus all CommonJS arguments ("CommonJS module scope").
+	See: https://nodejs.org/api/modules.html#modules_the_module_scope
 
-When analyzing code that is known to run outside of a CommonJS wrapper,
-e.g. JavaScript modules, `nodeBuiltin` can find accidental CommonJS references.
+When analyzing code that is known to run outside of a CommonJS wrapper, for example, JavaScript modules, `nodeBuiltin` can find accidental CommonJS references.
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,18 @@ console.log(globals.browser);
 
 Each global is given a value of `true` or `false`. A value of `true` indicates that the variable may be overwritten. A value of `false` indicates that the variable should be considered read-only. This information is used by static analysis tools to flag incorrect behavior. We assume all variables should be `false` unless we hear otherwise.
 
+For node.js this package provides two sets of globals:
+
+* `globals.nodeBuiltin`: Globals available to all code running in node.js.
+  These will usually be available as properties on the `global` object and
+  include `process`, `Buffer` but not CommonJS arguments like `require`.
+  See: https://nodejs.org/api/globals.html
+* `globals.node`: A combination of the globals from `nodeBuiltin` plus all
+  CommonJS arguments ("CommonJS module scope").
+  See: https://nodejs.org/api/modules.html#modules_the_module_scope
+
+When analyzing code that is known to run outside of a CommonJS wrapper,
+e.g. JavaScript modules, `nodeBuiltin` can find accidental CommonJS references.
 
 ---
 

--- a/test.js
+++ b/test.js
@@ -12,3 +12,25 @@ test('ensure alphabetical order', t => {
 		t.deepEqual(keys.slice(), keys.sort((a, b) => a.localeCompare(b)), `The \`${env}\` keys don't have the correct alphabetical order`);
 	}
 });
+
+test('node is nodeBuiltin with commonjs arguments', t => {
+	// M.commonjs has global which isn't a commonjs argument and doesn't include
+	// __filename and __dirname which are.
+	const commonjsArgs = {
+		__dirname: false,
+		__filename: false,
+		exports: true,
+		module: false,
+		require: false
+	};
+
+	t.deepEqual({...m.nodeBuiltin, ...commonjsArgs}, m.node);
+
+	// Ensure that there's no overlap between true globals and the CommonJS arguments above.
+	for (const builtin of Object.keys(m.nodeBuiltin)) {
+		t.true(
+			commonjsArgs[builtin] === undefined,
+			`The builtin ${builtin} is not a CommonJS argument`
+		);
+	}
+});

--- a/test.js
+++ b/test.js
@@ -13,9 +13,9 @@ test('ensure alphabetical order', t => {
 	}
 });
 
-test('node is nodeBuiltin with commonjs arguments', t => {
-	// M.commonjs has global which isn't a commonjs argument and doesn't include
-	// __filename and __dirname which are.
+test('`node` is `nodeBuiltin` with CommonJS arguments', t => {
+	// M.commonjs has global which isn't a CommonJS argument and doesn't include
+	// `__filename` and `__dirname` which are.
 	const commonjsArgs = {
 		__dirname: false,
 		__filename: false,


### PR DESCRIPTION
The `node` section mixes both globals and the arguments passed into CommonJS function bodies. This creates a new `nodeBuiltin` section that only includes the true globals. It's meant to be used  for ES modules or other code that runs outside of CommonJS wrappers.

---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.0.4)_