### PR TITLE
Remove `_` global from `meteor`

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -1299,7 +1299,6 @@
 		"Try": false
 	},
 	"meteor": {
-		"_": false,
 		"$": false,
 		"Accounts": false,
 		"AccountsClient": false,


### PR DESCRIPTION
The *underscore* package is not included in Meteor by default since Meteor 1.7 (https://github.com/meteor/meteor/pull/9596), so `_` is no longer in the global namespace by default. This removes `_` from the `meteor` globals group.