### PR TITLE
Update type-fest dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"environments"
 	],
 	"dependencies": {
-		"type-fest": "^0.8.1"
+		"type-fest": ">=0.8.1"
 	},
 	"devDependencies": {
 		"ava": "^2.2.0",


### PR DESCRIPTION
Current constraint will be satisfied by versions matching >=0.8.1 <0.9.0-0.
In this case, an error is thrown when the `type-fest` used by other dependencies does not match this version.
So update `^0.8.1` to `>=0.8.1`

This PR solves #170

## Reference
[Semver Ranges](https://github.com/npm/node-semver#ranges)
[Semver Caret Ranges](https://github.com/npm/node-semver#caret-ranges-123-025-004)
