### PR TITLE
Add `AggregateError` to `builtin` and `es2021`

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -1,5 +1,6 @@
 {
 	"builtin": {
+		"AggregateError": false,
 		"Array": false,
 		"ArrayBuffer": false,
 		"Atomics": false,
@@ -292,6 +293,7 @@
 		"WeakSet": false
 	},
 	"es2021": {
+		"AggregateError": false,
 		"Array": false,
 		"ArrayBuffer": false,
 		"Atomics": false,


### PR DESCRIPTION
Adds `AggregateError` global to `builtin` and `es2021` environments.

https://tc39.es/ecma262/#sec-aggregate-error-constructor:

> is the initial value of the "AggregateError" property of the global object.

Proposal: https://github.com/tc39/proposal-promise-any