### PR TITLE
Add `AbortController` to `node`

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -1144,6 +1144,7 @@
 	"node": {
 		"__dirname": false,
 		"__filename": false,
+		"AbortController": false,
 		"Buffer": false,
 		"clearImmediate": false,
 		"clearInterval": false,
@@ -1165,6 +1166,7 @@
 		"URLSearchParams": false
 	},
 	"nodeBuiltin": {
+		"AbortController": false,
 		"Buffer": false,
 		"clearImmediate": false,
 		"clearInterval": false,


### PR DESCRIPTION
Introduced in NodeJS v15. See details at https://nodejs.org/docs/latest-v15.x/api/globals.html#globals_class_abortcontroller . 

See also https://developer.mozilla.org/en-US/docs/Web/API/AbortController . 