### PR TITLE
Add `OverconstrainedError` to `browser` environment

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -787,6 +787,7 @@
 		"OscillatorNode": false,
 		"outerHeight": false,
 		"outerWidth": false,
+		"OverconstrainedError": false,
 		"PageTransitionEvent": false,
 		"pageXOffset": false,
 		"pageYOffset": false,


### PR DESCRIPTION
https://w3c.github.io/mediacapture-main/#overconstrainederror-interface