### PR TITLE
Remove trailing space from `AudioWorkletGlobalScope`

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -388,7 +388,7 @@
 		"AudioParam": false,
 		"AudioProcessingEvent": false,
 		"AudioScheduledSourceNode": false,
-		"AudioWorkletGlobalScope ": false,
+		"AudioWorkletGlobalScope": false,
 		"AudioWorkletNode": false,
 		"AudioWorkletProcessor": false,
 		"BarProp": false,


### PR DESCRIPTION
Removes a space character from the name of `AudioWorkletGlobalScope` browser global.