### PR TITLE
Add `MediaMetadata` to browser environment

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -646,6 +646,7 @@
 		"MediaKeyStatusMap": false,
 		"MediaKeySystemAccess": false,
 		"MediaList": false,
+		"MediaMetadata": false,
 		"MediaQueryList": false,
 		"MediaQueryListEvent": false,
 		"MediaRecorder": false,


### PR DESCRIPTION
https://w3c.github.io/mediasession/#dom-mediametadata-mediametadata
https://developer.mozilla.org/en-US/docs/Web/API/MediaMetadata/MediaMetadata

It is marked as "experimental" on MDN but it has landed in Chrome/Firefox/Safari. I hope that's cool.