### PR TITLE
Add MediaStreamConstraints interface to browsers environment

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -659,6 +659,7 @@
 		"MediaStream": false,
 		"MediaStreamAudioDestinationNode": false,
 		"MediaStreamAudioSourceNode": false,
+		"MediaStreamConstraints": false,
 		"MediaStreamEvent": false,
 		"MediaStreamTrack": false,
 		"MediaStreamTrackEvent": false,


### PR DESCRIPTION
MediaStreamConstraints is an interface used for the Media Streams API, see https://udn.realityripple.com/docs/Web/API/MediaStreamConstraints