### PR TITLE
Add `ToggleEvent`

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -1046,6 +1046,7 @@
 		"TextTrackCueList": false,
 		"TextTrackList": false,
 		"TimeRanges": false,
+		"ToggleEvent": false,
 		"toolbar": false,
 		"top": false,
 		"Touch": false,


### PR DESCRIPTION
Hi :)

The `ToggleEvent` is a new event that is called when a `popover` html element changes visibility.

I am trying to use it in a new project, and Eslint is not happy about it.

Reference: https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent