### PR TITLE
Add `webkitAudioContext` to `browser` globals

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -1087,6 +1087,7 @@
 		"WebGLTransformFeedback": false,
 		"WebGLUniformLocation": false,
 		"WebGLVertexArrayObject": false,
+		"webkitAudioContext": false,
 		"WebSocket": false,
 		"WebSocketError": false,
 		"WebSocketStream": false,


### PR DESCRIPTION
It was introduced before Safari/iOS 6 (https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/Using_HTML5_Audio_Video/PlayingandSynthesizingSounds/PlayingandSynthesizingSounds.html)

> Note: In Safari, the audio context has a prefix of webkit for backward-compatibility reasons. Since the Web Audio API is a work in progress, specification details may change.

...and as late as Safari 13, only `webkitAudioContext` is available vs. `AudioContext` (https://github.com/HaxeFoundation/haxe/issues/9862#issuecomment-684807345)

> Amazingly Safari 13 in 2020 does not support WebAudio without a prefix