### PR TITLE
Fix browser launch

### DIFF
--- a/scripts/get-browser-globals.mjs
+++ b/scripts/get-browser-globals.mjs
@@ -109,7 +109,7 @@ async function downloadBrowser({product} = {}) {
 async function getGlobalsInBrowser(environment, product = 'chrome') {
 	await downloadBrowser({product});
 
-	const browser = await puppeteer.launch({product});
+	const browser = await puppeteer.launch({browser: product});
 
 	try {
 		const version = await browser.version();


### PR DESCRIPTION
Maybe `puppeteer` updated function signature, currently we are not lunching Firefox correctly, so the scripts all running in Chrome.